### PR TITLE
Allow BusyBar to shrink

### DIFF
--- a/ui/CHANGES.md
+++ b/ui/CHANGES.md
@@ -1,4 +1,5 @@
 #### Version: 1.4.5-SNAPSHOT (LibGDX 1.9.10)
+- **Changed**: [#315](https://github.com/kotcrab/vis-ui/issues/315) Generify `VisTree` to match libGDX implementation.
 - **Changed**: [#314](https://github.com/kotcrab/vis-ui/issues/314) List `corner` Drawable wasn't set resulting in blank spot when both scrollbars were visible.
 
 #### Version: 1.4.4 (LibGDX 1.9.10)

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/BusyBar.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/BusyBar.java
@@ -55,7 +55,7 @@ public class BusyBar extends Widget {
 
 	@Override
 	public float getPrefWidth () {
-		return getWidth();
+		return style.segmentWidth;
 	}
 
 	@Override

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/VisTree.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/VisTree.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Tree;
+import com.badlogic.gdx.scenes.scene2d.ui.Tree.Node;
 import com.kotcrab.vis.ui.FocusManager;
 import com.kotcrab.vis.ui.Focusable;
 import com.kotcrab.vis.ui.VisUI;
@@ -30,7 +31,7 @@ import com.kotcrab.vis.ui.VisUI;
  * @author Kotcrab
  * @see Tree
  */
-public class VisTree extends Tree {
+public class VisTree<N extends Node, V> extends Tree<N, V> {
 	public VisTree (String styleName) {
 		super(VisUI.getSkin(), styleName);
 		init();


### PR DESCRIPTION
Returning `getWidth()` dynamically for `getPrefWidth()` allows
`BusyBar` to grow but not shrink when the parent layout resizes.

`segmentWidth` should be a sensible `prefWidth` for this widget.

This is to address #316 