### PR TITLE
Allow BusyBar to shrink

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/BusyBar.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/BusyBar.java
@@ -55,7 +55,7 @@ public class BusyBar extends Widget {
 
 	@Override
 	public float getPrefWidth () {
-		return getWidth();
+		return style.segmentWidth;
 	}
 
 	@Override


### PR DESCRIPTION
Returning `getWidth()` dynamically for `getPrefWidth()` allows
`BusyBar` to grow but not shrink when the parent layout resizes.

`segmentWidth` should be a sensible `prefWidth` for this widget.

This is to address #316.