### PR TITLE
Added VisImageButton constructor for images (up/down/checked) and stylename based buttons.

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/VisImageButton.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/VisImageButton.java
@@ -73,6 +73,15 @@ public class VisImageButton extends Button implements Focusable, BorderOwner {
 		init();
 	}
 
+	public VisImageButton (Drawable imageUp, Drawable imageDown, Drawable imageChecked, String styleName) {
+		super(new VisImageButtonStyle(VisUI.getSkin().get(styleName, VisImageButtonStyle.class)));
+		style.imageUp = imageUp;
+		style.imageDown = imageDown;
+		style.imageChecked = imageChecked;
+
+		init();
+	}
+
 	public VisImageButton (String styleName) {
 		super(new VisImageButtonStyle(VisUI.getSkin().get(styleName, VisImageButtonStyle.class)));
 		init();


### PR DESCRIPTION
As far as I understand the source code, it's currently not possible to create a VisImageButton which uses the "toggle" stylename (=> the blue background, without the "toggle" style it would have no blue background).

Therefore, I added a new constructor for the VisImageButton class which allows you to do that.

Example code:

```java
table.add(new VisImageButton(upImage, downImage, checkedImage, "toggle"));
```

Example image ( Thanks @travall ):

![Untitled](https://user-images.githubusercontent.com/11274700/90828313-13ed0780-e33e-11ea-9d60-42a4646659aa.png)

