### PR TITLE
Fix font lost parentAlpha in HighlightTextArea

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/HighlightTextArea.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/HighlightTextArea.java
@@ -162,7 +162,7 @@ public class HighlightTextArea extends ScrollableTextArea {
 			for (Chunk chunk : renderChunks) {
 				if (chunk.lineIndex == i) {
 					font.setColor(chunk.color);
-					font.getColor().a = parentAlpha;
+					font.getColor().a *= parentAlpha;
 					font.draw(batch, chunk.text, x + chunk.offsetX, y + offsetY);
 				}
 			}

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/HighlightTextArea.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/HighlightTextArea.java
@@ -157,10 +157,12 @@ public class HighlightTextArea extends ScrollableTextArea {
 	protected void drawText (Batch batch, BitmapFont font, float x, float y) {
 		maxAreaHeight = 0;
 		float offsetY = 0;
+		float parentAlpha = font.getColor().a;
 		for (int i = firstLineShowing * 2; i < (firstLineShowing + linesShowing) * 2 && i < linesBreak.size; i += 2) {
 			for (Chunk chunk : renderChunks) {
 				if (chunk.lineIndex == i) {
 					font.setColor(chunk.color);
+					font.getColor().a = parentAlpha;
 					font.draw(batch, chunk.text, x + chunk.offsetX, y + offsetY);
 				}
 			}


### PR DESCRIPTION
In HighlightTextArea font color is overwritten by chunk color. This color doesn't know anything about parent alpha and thus all the work done [here](https://github.com/kotcrab/vis-ui/blob/ba66b2313da273d8358275956904dc76b29f9dae/ui/src/main/java/com/kotcrab/vis/ui/widget/VisTextField.java#L366) in VisTextField is useless.
This commit saves original parent alpha value and restore it after chunk color set.

This fix prevent some ugly animations when HighlightTextArea is placed for example in a Dialog that fades in and out.

You can test with `TestHighlightTextArea` too, just change the alpha of the window.

Thanks