### PR TITLE
Use `showMenu` function to open MenuItem's subMenu

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/MenuItem.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/MenuItem.java
@@ -211,14 +211,10 @@ public class MenuItem extends Button {
 			subMenuX = pos.x - subMenu.getWidth() + 1;
 		}
 
-		subMenu.setPosition(subMenuX, pos.y - subMenu.getHeight() + getHeight());
-
-		if (subMenu.getY() < 0) {
-			subMenu.setY(subMenu.getY() + subMenu.getHeight() - getHeight());
+		if (containerMenu.getActiveSubMenu() != subMenu) {
+			subMenu.showMenu(stage, subMenuX, pos.y + getHeight());
+			containerMenu.setActiveSubMenu(subMenu);
 		}
-
-		stage.addActor(subMenu);
-		containerMenu.setActiveSubMenu(subMenu);
 	}
 
 	void fireChangeEvent () {

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/MenuItem.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/MenuItem.java
@@ -212,7 +212,10 @@ public class MenuItem extends Button {
 		}
 
 		if (containerMenu.getActiveSubMenu() != subMenu) {
-			subMenu.showMenu(stage, subMenuX, pos.y + getHeight());
+			boolean hasEnoughBottomSpace = stage.getHeight() - (pos.y + getHeight()) + subMenu.getHeight() <= stage.getHeight();
+			float heightCorrection = hasEnoughBottomSpace ? getHeight() : 0;
+
+			subMenu.showMenu(stage, subMenuX, pos.y + heightCorrection);
 			containerMenu.setActiveSubMenu(subMenu);
 		}
 	}

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/PopupMenu.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/PopupMenu.java
@@ -180,7 +180,7 @@ public class PopupMenu extends Table {
 	}
 
 	private void removeHierarchy () {
-		if (activeItem != null && activeItem.containerMenu.parentSubMenu != null) {
+		if (activeItem != null && activeItem.containerMenu != null && activeItem.containerMenu.parentSubMenu != null) {
 			activeItem.containerMenu.parentSubMenu.removeHierarchy();
 		}
 		remove();
@@ -321,6 +321,10 @@ public class PopupMenu extends Table {
 		if (newSubMenu != null) {
 			newSubMenu.setParentMenu(this);
 		}
+	}
+
+	public PopupMenu getActiveSubMenu () {
+		return activeSubMenu;
 	}
 
 	@Override


### PR DESCRIPTION
I've made a custom class that extends `PopupMenu` with the intention of animate, and so override, show and hide functions to create a smooth and nice transition. It works well, but not for subMenus because they are directly add to the stage with `addActor` rather then use `showMenu`.
I've also add a check to prevent that `showMenu` is called when not necessary (when the subMenu is already added).
Thanks