### PR TITLE
Fix `CollapsibleWidget` scissors

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/CollapsibleWidget.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/CollapsibleWidget.java
@@ -113,7 +113,7 @@ public class CollapsibleWidget extends WidgetGroup {
 
 	@Override
 	public void draw (Batch batch, float parentAlpha) {
-		if (currentHeight > 1) {
+		if (currentHeight > 1 && getY() + currentHeight > 1) {
 			batch.flush();
 			boolean clipEnabled = clipBegin(getX(), getY(), getWidth(), currentHeight);
 

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/HorizontalCollapsibleWidget.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/HorizontalCollapsibleWidget.java
@@ -104,7 +104,7 @@ public class HorizontalCollapsibleWidget extends WidgetGroup {
 
 	@Override
 	public void draw (Batch batch, float parentAlpha) {
-		if (currentWidth > 1) {
+		if (currentWidth > 1 && getX() + currentWidth > 1) {
 			batch.flush();
 			boolean clipEnabled = clipBegin(getX(), getY(), currentWidth, getHeight());
 


### PR DESCRIPTION
Hi,
I've noticed that when a `CollapsibleWidget` is placed in a scroll pane and it's partially visible scissors doesn't get applied because `ScissorStack.pushScissors` fails, this produce bugs like that:

![collapsiblewidget-bug](https://user-images.githubusercontent.com/5543339/111038226-289f0300-8428-11eb-96f8-286136c294dd.gif)

Checking Y position before rendering should fix the problem, let me know.

Thanks!
 