### PR TITLE
Fix `CollapsibleWidget` performance issue

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/CollapsibleWidget.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/CollapsibleWidget.java
@@ -114,13 +114,17 @@ public class CollapsibleWidget extends WidgetGroup {
 	@Override
 	public void draw (Batch batch, float parentAlpha) {
 		if (currentHeight > 1 && getY() + currentHeight > 1) {
-			batch.flush();
-			boolean clipEnabled = clipBegin(getX(), getY(), getWidth(), currentHeight);
+			if (actionRunning) {
+				batch.flush();
+				boolean clipEnabled = clipBegin(getX(), getY(), getWidth(), currentHeight);
 
-			super.draw(batch, parentAlpha);
+				super.draw(batch, parentAlpha);
 
-			batch.flush();
-			if (clipEnabled) clipEnd();
+				batch.flush();
+				if (clipEnabled) clipEnd();
+			} else {
+				super.draw(batch, parentAlpha);
+			}
 		}
 	}
 

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/HorizontalCollapsibleWidget.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/HorizontalCollapsibleWidget.java
@@ -105,13 +105,17 @@ public class HorizontalCollapsibleWidget extends WidgetGroup {
 	@Override
 	public void draw (Batch batch, float parentAlpha) {
 		if (currentWidth > 1 && getX() + currentWidth > 1) {
-			batch.flush();
-			boolean clipEnabled = clipBegin(getX(), getY(), currentWidth, getHeight());
+			if (actionRunning) {
+				batch.flush();
+				boolean clipEnabled = clipBegin(getX(), getY(), currentWidth, getHeight());
 
-			super.draw(batch, parentAlpha);
+				super.draw(batch, parentAlpha);
 
-			batch.flush();
-			if (clipEnabled) clipEnd();
+				batch.flush();
+				if (clipEnabled) clipEnd();
+			} else {
+				super.draw(batch, parentAlpha);
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi, I've found a very huge performance degradation using `CollapsibleWidget` due to its abuse of scissors and batch flushes. Indeed, view should be clipped only when animation is running to give the desired effect, however when widget is fully expanded clip is no more necessary.