### PR TITLE
Update libGDX wiki link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VisUI is licensed under Apache2 license meaning that you can use it for free in 
 
 ## Adding VisUI to your project
 
-Please refer to [libGDX documentation](https://github.com/libgdx/libgdx/wiki/Dependency-management-with-Gradle) if you don't know how to mange dependencies with Gradle. Alternatively JAR can be downloaded from [Maven repository](http://search.maven.org/#search|gav|1|g%3A%22com.kotcrab.vis%22%20AND%20a%3A%22vis-ui%22). If you are creating new project, you can use gdx-setup to automatically add VisUI for you. (press 'Show Third Party Extension' button)
+Please refer to [libGDX documentation](https://libgdx.com/wiki/articles/dependency-management-with-gradle) if you don't know how to mange dependencies with Gradle. Alternatively JAR can be downloaded from [Maven repository](http://search.maven.org/#search|gav|1|g%3A%22com.kotcrab.vis%22%20AND%20a%3A%22vis-ui%22). If you are creating new project, you can use gdx-setup to automatically add VisUI for you. (press 'Show Third Party Extension' button)
 
 #### Manual Gradle setup: 
 Open build.gradle in project root.


### PR DESCRIPTION
Fixes the libGDX wiki link which was broken in the course of the recent [wiki migration](https://libgdx.com/news/2022/01/devlog-8-wiki-migration).