### PR TITLE
Add VisImageTextButton orientation parameter (#373)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,3 +20,4 @@ metaphore https://github.com/metaphore
 cypherdare https://github.com/cypherdare
 fgnm https://github.com/fgnm
 ccmb2r https://github.com/ccmb2r
+bploeckelman https://github.com/bploeckelman

--- a/ui/CHANGES.md
+++ b/ui/CHANGES.md
@@ -1,4 +1,6 @@
 #### Version: 1.5.2-SNAPSHOT (libGDX 1.11.0)
+- **Added**: [#373](https://github.com/kotcrab/vis-ui/issues/373) - `VisImageTextButton` an optional `Orientation` value can be set to change how the button label is positioned relative to the button image
+  - Defaults to existing behavior (label to the right of image in the same row), and orientation can be changed via `VisImageTextButton.setOrientation()`
 
 #### Version: 1.5.1 (libGDX 1.11.0)
 - Updated to libGDX 1.11.0

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/VisImageTextButton.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/VisImageTextButton.java
@@ -48,7 +48,7 @@ import com.kotcrab.vis.ui.widget.VisTextButton.VisTextButtonStyle;
  * @see Button
  */
 public class VisImageTextButton extends Button implements Focusable, BorderOwner {
-	public enum Orientation { text_right, text_left, text_top, text_bottom }
+	public enum Orientation { TEXT_RIGHT, TEXT_LEFT, TEXT_TOP, TEXT_BOTTOM }
 
 	private Image image;
 	private Label label;
@@ -59,7 +59,7 @@ public class VisImageTextButton extends Button implements Focusable, BorderOwner
 	private boolean generateDisabledImage = false;
 
 	private VisImageTextButtonStyle style;
-	private Orientation orientation = Orientation.text_right;
+	private Orientation orientation = Orientation.TEXT_RIGHT;
 
 	public VisImageTextButton (String text, Drawable imageUp) {
 		this(text, "default", imageUp, null);
@@ -113,20 +113,20 @@ public class VisImageTextButton extends Button implements Focusable, BorderOwner
 
 	private void addActorsBasedOnOrientation() {
 		switch (orientation) {
-			case text_right:
+			case TEXT_RIGHT:
 				add(image);
 				add(label);
 				break;
-			case text_left:
+			case TEXT_LEFT:
 				add(label);
 				add(image);
 				break;
-			case text_top:
+			case TEXT_TOP:
 				add(label);
 				row();
 				add(image);
 				break;
-			case text_bottom:
+			case TEXT_BOTTOM:
 				add(image);
 				row();
 				add(label);

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/VisImageTextButton.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/VisImageTextButton.java
@@ -48,6 +48,8 @@ import com.kotcrab.vis.ui.widget.VisTextButton.VisTextButtonStyle;
  * @see Button
  */
 public class VisImageTextButton extends Button implements Focusable, BorderOwner {
+	public enum Orientation { text_right, text_left, text_top, text_bottom }
+
 	private Image image;
 	private Label label;
 
@@ -57,6 +59,7 @@ public class VisImageTextButton extends Button implements Focusable, BorderOwner
 	private boolean generateDisabledImage = false;
 
 	private VisImageTextButtonStyle style;
+	private Orientation orientation = Orientation.text_right;
 
 	public VisImageTextButton (String text, Drawable imageUp) {
 		this(text, "default", imageUp, null);
@@ -89,11 +92,30 @@ public class VisImageTextButton extends Button implements Focusable, BorderOwner
 
 		image = new Image();
 		image.setScaling(Scaling.fit);
-		add(image);
 
 		label = new Label(text, new LabelStyle(style.font, style.fontColor));
 		label.setAlignment(Align.center);
-		add(label);
+
+		switch (orientation) {
+			case text_right:
+				add(image);
+				add(label);
+				break;
+			case text_left:
+				add(label);
+				add(image);
+				break;
+			case text_top:
+				add(label);
+				row();
+				add(image);
+				break;
+			case text_bottom:
+				add(image);
+				row();
+				add(label);
+				break;
+		}
 
 		setStyle(style);
 
@@ -170,6 +192,17 @@ public class VisImageTextButton extends Button implements Focusable, BorderOwner
 		super.draw(batch, parentAlpha);
 		if (focusBorderEnabled && drawBorder && style.focusBorder != null)
 			style.focusBorder.draw(batch, getX(), getY(), getWidth(), getHeight());
+	}
+
+	public Orientation getOrientation() {
+		return orientation;
+	}
+
+	public void setOrientation(Orientation orientation) {
+		this.orientation = orientation;
+		CharSequence text = getText();
+		clear();
+		init(text.toString());
 	}
 
 	public Image getImage () {

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/VisImageTextButton.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/VisImageTextButton.java
@@ -96,6 +96,22 @@ public class VisImageTextButton extends Button implements Focusable, BorderOwner
 		label = new Label(text, new LabelStyle(style.font, style.fontColor));
 		label.setAlignment(Align.center);
 
+		addActorsBasedOnOrientation();
+
+		setStyle(style);
+
+		setSize(getPrefWidth(), getPrefHeight());
+
+		addListener(new InputListener() {
+			@Override
+			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
+				if (isDisabled() == false) FocusManager.switchFocus(getStage(), VisImageTextButton.this);
+				return false;
+			}
+		});
+	}
+
+	private void addActorsBasedOnOrientation() {
 		switch (orientation) {
 			case text_right:
 				add(image);
@@ -116,18 +132,6 @@ public class VisImageTextButton extends Button implements Focusable, BorderOwner
 				add(label);
 				break;
 		}
-
-		setStyle(style);
-
-		setSize(getPrefWidth(), getPrefHeight());
-
-		addListener(new InputListener() {
-			@Override
-			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
-				if (isDisabled() == false) FocusManager.switchFocus(getStage(), VisImageTextButton.this);
-				return false;
-			}
-		});
 	}
 
 	@Override
@@ -200,9 +204,8 @@ public class VisImageTextButton extends Button implements Focusable, BorderOwner
 
 	public void setOrientation(Orientation orientation) {
 		this.orientation = orientation;
-		CharSequence text = getText();
-		clear();
-		init(text.toString());
+		clearChildren();
+		addActorsBasedOnOrientation();
 	}
 
 	public Image getImage () {

--- a/ui/src/test/java/com/kotcrab/vis/ui/test/TestImageTextButtonOrientation.java
+++ b/ui/src/test/java/com/kotcrab/vis/ui/test/TestImageTextButtonOrientation.java
@@ -1,0 +1,46 @@
+package com.kotcrab.vis.ui.test;
+
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+import com.kotcrab.vis.ui.VisUI;
+import com.kotcrab.vis.ui.util.TableUtils;
+import com.kotcrab.vis.ui.widget.VisImageTextButton;
+import com.kotcrab.vis.ui.widget.VisLabel;
+import com.kotcrab.vis.ui.widget.VisWindow;
+
+public class TestImageTextButtonOrientation extends VisWindow {
+    public TestImageTextButtonOrientation() {
+        super("text image button orientation");
+
+        TableUtils.setSpacingDefaults(this);
+        columnDefaults(0).left();
+
+        addVisWidgets();
+
+        setSize(400, 250);
+        centerWindow();
+    }
+
+    private void addVisWidgets () {
+        Drawable icon = VisUI.getSkin().getDrawable("icon-folder");
+
+        VisImageTextButton right = new VisImageTextButton("right", icon);
+        VisImageTextButton left = new VisImageTextButton("left", icon);
+        VisImageTextButton top = new VisImageTextButton("top", icon);
+        VisImageTextButton bottom = new VisImageTextButton("bottom", icon);
+
+        // 'text_right' is the default orientation for backwards compatibility, so no need to set it explicitly
+        // right.setOrientation(VisImageTextButton.Orientation.text_right);
+        left.setOrientation(VisImageTextButton.Orientation.text_left);
+        top.setOrientation(VisImageTextButton.Orientation.text_top);
+        bottom.setOrientation(VisImageTextButton.Orientation.text_bottom);
+
+        add(new VisLabel("VisImageTextButton text_right (default)"));
+        add(right).row();
+        add(new VisLabel("VisImageTextButton text_left"));
+        add(left).row();
+        add(new VisLabel("VisImageTextButton text_top"));
+        add(top).row();
+        add(new VisLabel("VisImageTextButton text_bottom"));
+        add(bottom).padBottom(3f).row();
+    }
+}

--- a/ui/src/test/java/com/kotcrab/vis/ui/test/TestImageTextButtonOrientation.java
+++ b/ui/src/test/java/com/kotcrab/vis/ui/test/TestImageTextButtonOrientation.java
@@ -30,17 +30,17 @@ public class TestImageTextButtonOrientation extends VisWindow {
 
         // 'text_right' is the default orientation for backwards compatibility, so no need to set it explicitly
         // right.setOrientation(VisImageTextButton.Orientation.text_right);
-        left.setOrientation(VisImageTextButton.Orientation.text_left);
-        top.setOrientation(VisImageTextButton.Orientation.text_top);
-        bottom.setOrientation(VisImageTextButton.Orientation.text_bottom);
+        left.setOrientation(VisImageTextButton.Orientation.TEXT_LEFT);
+        top.setOrientation(VisImageTextButton.Orientation.TEXT_TOP);
+        bottom.setOrientation(VisImageTextButton.Orientation.TEXT_BOTTOM);
 
-        add(new VisLabel("VisImageTextButton text_right (default)"));
+        add(new VisLabel("VisImageTextButton TEXT_RIGHT (default)"));
         add(right).row();
-        add(new VisLabel("VisImageTextButton text_left"));
+        add(new VisLabel("VisImageTextButton TEXT_LEFT"));
         add(left).row();
-        add(new VisLabel("VisImageTextButton text_top"));
+        add(new VisLabel("VisImageTextButton TEXT_TOP"));
         add(top).row();
-        add(new VisLabel("VisImageTextButton text_bottom"));
+        add(new VisLabel("VisImageTextButton TEXT_BOTTOM"));
         add(bottom).padBottom(3f).row();
     }
 }

--- a/ui/src/test/java/com/kotcrab/vis/ui/test/manual/TestLauncher.java
+++ b/ui/src/test/java/com/kotcrab/vis/ui/test/manual/TestLauncher.java
@@ -29,6 +29,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import com.kotcrab.vis.ui.VisUI;
 import com.kotcrab.vis.ui.VisUI.SkinScale;
+import com.kotcrab.vis.ui.test.TestImageTextButtonOrientation;
 import com.kotcrab.vis.ui.util.dialog.Dialogs;
 import com.kotcrab.vis.ui.widget.Menu;
 import com.kotcrab.vis.ui.widget.MenuBar;
@@ -260,6 +261,12 @@ class TestApplication extends ApplicationAdapter {
 			@Override
 			public void changed (ChangeEvent event, Actor actor) {
 				stage.addActor(new TestGenerateDisabledImage());
+			}
+		}));
+		menu.addItem(new MenuItem("imagetextbutton orientation", new ChangeListener() {
+			@Override
+			public void changed (ChangeEvent event, Actor actor) {
+				stage.addActor(new TestImageTextButtonOrientation());
 			}
 		}));
 		menu.addSeparator();


### PR DESCRIPTION
These changes add an `orientation` parameter to `VisImageTextButton` that allows the user to specify how they want the label orientated relative to the image in the button table.

Available options are `TEXT_RIGHT` (the default, which matches the existing behavior of `VisImageTextButton`), `TEXT_LEFT`, `TEXT_TOP`, and `TEXT_BOTTOM`. 

It also adds a small test that demonstrates the possible orientations.

There are a couple places where I'd like feedback about the api, so I'm marking this as a draft:
- The naming of the `Orientation` enum  and it's values
- Not providing a way to specify an orientation in a constructor (not sure what the signature of such a constructor(s) should look like)
- How orientation changes are applied (ie. re-running `init()` after clearing existing children/listener(s) when calling `setOrientation(...)`)

Once the api is finalized and relevant changes are made (if any), I'll add another commit to update `CHANGES.md` and finish the pull request.