### PR TITLE
Remove reference to internal class

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ VisUI is licensed under Apache2 license meaning that you can use it for free in 
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.kotcrab.vis/vis-ui.svg)](https://search.maven.org/artifact/com.kotcrab.vis/vis-ui)
 
-Please refer to [libGDX documentation](https://libgdx.com/wiki/articles/dependency-management-with-gradle) if you don't know how to mange dependencies with Gradle. Alternatively JAR can be downloaded from [Maven repository](http://search.maven.org/#search|gav|1|g%3A%22com.kotcrab.vis%22%20AND%20a%3A%22vis-ui%22). If you are creating new project, you can use gdx-setup to automatically add VisUI for you. (press 'Show Third Party Extension' button)
+Please refer to [libGDX documentation](https://libgdx.com/wiki/articles/dependency-management-with-gradle) if you don't know how to manage dependencies with Gradle. Alternatively JAR can be downloaded from [Maven repository](http://search.maven.org/#search|gav|1|g%3A%22com.kotcrab.vis%22%20AND%20a%3A%22vis-ui%22). If you are creating new project, you can use gdx-setup to automatically add VisUI for you. (press 'Show Third Party Extension' button)
 
 #### Manual Gradle setup:
 

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/file/FileUtils.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/file/FileUtils.java
@@ -16,7 +16,6 @@
 
 package com.kotcrab.vis.ui.widget.file;
 
-import com.apple.eio.FileManager;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
@@ -164,19 +163,15 @@ public class FileUtils {
 			dirToShow = dir.parent().file();
 		}
 
-		if (OsUtils.isMac()) {
-			FileManager.revealInFinder(dirToShow);
-		} else {
-			try {
-				// Using reflection to avoid importing AWT desktop which would trigger Android Lint errors
-				// This is desktop only, rarely called, performance drop is negligible
-				// Basically 'Desktop.getDesktop().open(dirToShow);'
-				Class desktopClass = Class.forName("java.awt.Desktop");
-				Object desktop = desktopClass.getMethod("getDesktop").invoke(null);
-				desktopClass.getMethod("open", File.class).invoke(desktop, dirToShow);
-			} catch (Exception e) {
-				Gdx.app.log("VisUI", "Can't open file " + dirToShow.getPath(), e);
-			}
-		}
-	}
+        try {
+            // Using reflection to avoid importing AWT desktop which would trigger Android Lint errors
+            // This is desktop only, rarely called, performance drop is negligible
+            // Basically 'Desktop.getDesktop().open(dirToShow);'
+            Class desktopClass = Class.forName("java.awt.Desktop");
+            Object desktop = desktopClass.getMethod("getDesktop").invoke(null);
+            desktopClass.getMethod("open", File.class).invoke(desktop, dirToShow);
+        } catch (Exception e) {
+            Gdx.app.log("VisUI", "Can't open file " + dirToShow.getPath(), e);
+        }
+    }
 }

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/file/FileUtils.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/file/FileUtils.java
@@ -169,7 +169,12 @@ public class FileUtils {
             // Basically 'Desktop.getDesktop().open(dirToShow);'
             Class desktopClass = Class.forName("java.awt.Desktop");
             Object desktop = desktopClass.getMethod("getDesktop").invoke(null);
-            desktopClass.getMethod("open", File.class).invoke(desktop, dirToShow);
+			try {
+				// browseFileDirectory was introduced in JDK 9
+				desktopClass.getMethod("browseFileDirectory", File.class).invoke(desktop, dirToShow);
+			} catch (NoSuchMethodException ignored) {
+				desktopClass.getMethod("open", File.class).invoke(desktop, dirToShow);
+			}
         } catch (Exception e) {
             Gdx.app.log("VisUI", "Can't open file " + dirToShow.getPath(), e);
         }

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/file/FileUtils.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/file/FileUtils.java
@@ -24,6 +24,7 @@ import com.kotcrab.vis.ui.util.OsUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.text.DecimalFormat;
 import java.util.Comparator;
 
@@ -172,7 +173,13 @@ public class FileUtils {
 			try {
 				// browseFileDirectory was introduced in JDK 9
 				desktopClass.getMethod("browseFileDirectory", File.class).invoke(desktop, dirToShow);
-			} catch (NoSuchMethodException ignored) {
+			} catch (NoSuchMethodException | InvocationTargetException e) {
+				// browseFileDirectory throws UnsupportedOperationException on some platforms, which is then
+				// wrapped in InvocationTargetException because it's accessed via reflection.
+				// throw again all other exceptions we didn't expect
+				if (e instanceof InvocationTargetException && !(e.getCause() instanceof UnsupportedOperationException)) {
+					throw e;
+				}
 				desktopClass.getMethod("open", File.class).invoke(desktop, dirToShow);
 			}
 		} catch (Exception e) {

--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/file/FileUtils.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/file/FileUtils.java
@@ -163,20 +163,20 @@ public class FileUtils {
 			dirToShow = dir.parent().file();
 		}
 
-        try {
-            // Using reflection to avoid importing AWT desktop which would trigger Android Lint errors
-            // This is desktop only, rarely called, performance drop is negligible
-            // Basically 'Desktop.getDesktop().open(dirToShow);'
-            Class desktopClass = Class.forName("java.awt.Desktop");
-            Object desktop = desktopClass.getMethod("getDesktop").invoke(null);
+		try {
+			// Using reflection to avoid importing AWT desktop which would trigger Android Lint errors
+			// This is desktop only, rarely called, performance drop is negligible
+			// Basically 'Desktop.getDesktop().open(dirToShow);'
+			Class desktopClass = Class.forName("java.awt.Desktop");
+			Object desktop = desktopClass.getMethod("getDesktop").invoke(null);
 			try {
 				// browseFileDirectory was introduced in JDK 9
 				desktopClass.getMethod("browseFileDirectory", File.class).invoke(desktop, dirToShow);
 			} catch (NoSuchMethodException ignored) {
 				desktopClass.getMethod("open", File.class).invoke(desktop, dirToShow);
 			}
-        } catch (Exception e) {
-            Gdx.app.log("VisUI", "Can't open file " + dirToShow.getPath(), e);
-        }
-    }
+		} catch (Exception e) {
+			Gdx.app.log("VisUI", "Can't open file " + dirToShow.getPath(), e);
+		}
+	}
 }


### PR DESCRIPTION
This PR removes references to the class `com.apple.eio.FileManager` as it's part of an internal API, and creates problems when trying to package an application via `jlink`. We notice this being a problem in the libgdx discord server a couple times, with the following error:

```
Error: Module JDK removed internal API/com.apple.eio not found
java.lang.module.FindException: Module JDK removed internal API/com.apple.eio not found
        at java.base/java.lang.module.Resolver.findFail(Resolver.java:893)
        at java.base/java.lang.module.Resolver.resolve(Resolver.java:129)
        at java.base/java.lang.module.Configuration.resolve(Configuration.java:421)
        at java.base/java.lang.module.Configuration.resolve(Configuration.java:255)
        at jdk.jlink/jdk.tools.jlink.internal.Jlink$JlinkConfiguration.resolve(Jlink.java:217)
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImageProvider(JlinkTask.java:536)
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImage(JlinkTask.java:424)
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.run(JlinkTask.java:276)
        at jdk.jlink/jdk.tools.jlink.internal.Main.run(Main.java:55)
        at jdk.jlink/jdk.tools.jlink.internal.Main.main(Main.java:33)
```

I also noticed a typo in the readme and fixed it

**Note**: I don't have an Apple computer so I couldn't try these changes there, the way I tested it was by adding a new module to the project, with the following changes:

```gradle
// settings.gradle
rootProject.name = 'vis-ui'
rootProject.buildFileName = 'build.gradle'
include 'ui', 'usl'
include 'example'
```
```gradle
// example/build.gradle
plugins {
    id("java")
}

repositories {
    mavenCentral()
}

dependencies {
    implementation("com.badlogicgames.gdx:gdx:1.12.1")
    implementation("com.badlogicgames.gdx:gdx-platform:1.12.1:natives-desktop")
    implementation("com.badlogicgames.gdx:gdx-backend-lwjgl3:1.12.1")
    implementation(project(":ui"))
}
```
```java
// example/src/main/java/org/example/DesktopLauncher.java
package org.example;

import com.badlogic.gdx.Game;
import com.badlogic.gdx.Gdx;
import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
import com.badlogic.gdx.graphics.Color;
import com.badlogic.gdx.graphics.glutils.HdpiMode;
import com.badlogic.gdx.scenes.scene2d.Stage;
import com.badlogic.gdx.utils.ScreenUtils;
import com.kotcrab.vis.ui.VisUI;
import com.kotcrab.vis.ui.widget.file.FileChooser;
import org.lwjgl.glfw.GLFW;

public class DesktopLauncher {

    public static void main(String[] arg) {
        Lwjgl3ApplicationConfiguration.getDisplayMode();
        long monitor = GLFW.glfwGetMonitors().get(0);
        float[] scaleX = new float[1];
        float[] scaleY = new float[1];
        GLFW.glfwGetMonitorContentScale(monitor, scaleX, scaleY);
        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
        config.setForegroundFPS(60);
        config.setTitle("Game");
        config.setHdpiMode(HdpiMode.Pixels);
        setWindowedMode(config, scaleX[0], scaleY[0]);
        new Lwjgl3Application(new GdxGame(), config);
    }

    private static void setWindowedMode(Lwjgl3ApplicationConfiguration config, float scaleX, float scaleY) {
        int width = (int) (720 * scaleX);
        int height = (int) (450 * scaleY);
        config.setWindowedMode(width, height);
    }

    public static class GdxGame extends Game {

        private Stage stage;

        @Override
        public void create() {
            VisUI.load(VisUI.SkinScale.X2);
            stage = new Stage();
            Gdx.input.setInputProcessor(stage);
            stage.addActor(new FileChooser(FileChooser.Mode.OPEN));
        }

        @Override
        public void render() {
            super.render();
            ScreenUtils.clear(Color.BLACK);
            stage.act();
            stage.draw();
        }
    }
}
```

Then right clicking one of the files in the list, and picking "Show in explorer"
